### PR TITLE
fix backwards compat with php 5.3 array syntax

### DIFF
--- a/tests/Dotenv/ValidatorBooleanTest.php
+++ b/tests/Dotenv/ValidatorBooleanTest.php
@@ -21,31 +21,31 @@ class ValidatorBooleanTest extends PHPUnit_Framework_TestCase
      */
     public function validBooleanValuesDataProvider()
     {
-        return [
-            ['VALID_EXPLICIT_LOWERCASE_TRUE'],
-            ['VALID_EXPLICIT_LOWERCASE_FALSE'],
-            ['VALID_EXPLICIT_UPPERCASE_TRUE'],
-            ['VALID_EXPLICIT_UPPERCASE_FALSE'],
-            ['VALID_EXPLICIT_MIXEDCASE_TRUE'],
-            ['VALID_EXPLICIT_MIXEDCASE_FALSE'],
+        return array(
+            array('VALID_EXPLICIT_LOWERCASE_TRUE'),
+            array('VALID_EXPLICIT_LOWERCASE_FALSE'),
+            array('VALID_EXPLICIT_UPPERCASE_TRUE'),
+            array('VALID_EXPLICIT_UPPERCASE_FALSE'),
+            array('VALID_EXPLICIT_MIXEDCASE_TRUE'),
+            array('VALID_EXPLICIT_MIXEDCASE_FALSE'),
 
-            ['VALID_NUMBER_TRUE'],
-            ['VALID_NUMBER_FALSE'],
+            array('VALID_NUMBER_TRUE'),
+            array('VALID_NUMBER_FALSE'),
 
-            ['VALID_ONOFF_LOWERCASE_TRUE'],
-            ['VALID_ONOFF_LOWERCASE_FALSE'],
-            ['VALID_ONOFF_UPPERCASE_TRUE'],
-            ['VALID_ONOFF_UPPERCASE_FALSE'],
-            ['VALID_ONOFF_MIXEDCASE_TRUE'],
-            ['VALID_ONOFF_MIXEDCASE_FALSE'],
+            array('VALID_ONOFF_LOWERCASE_TRUE'),
+            array('VALID_ONOFF_LOWERCASE_FALSE'),
+            array('VALID_ONOFF_UPPERCASE_TRUE'),
+            array('VALID_ONOFF_UPPERCASE_FALSE'),
+            array('VALID_ONOFF_MIXEDCASE_TRUE'),
+            array('VALID_ONOFF_MIXEDCASE_FALSE'),
 
-            ['VALID_YESNO_LOWERCASE_TRUE'],
-            ['VALID_YESNO_LOWERCASE_FALSE'],
-            ['VALID_YESNO_UPPERCASE_TRUE'],
-            ['VALID_YESNO_UPPERCASE_FALSE'],
-            ['VALID_YESNO_MIXEDCASE_TRUE'],
-            ['VALID_YESNO_MIXEDCASE_FALSE'],
-        ];
+            array('VALID_YESNO_LOWERCASE_TRUE'),
+            array('VALID_YESNO_LOWERCASE_FALSE'),
+            array('VALID_YESNO_UPPERCASE_TRUE'),
+            array('VALID_YESNO_UPPERCASE_FALSE'),
+            array('VALID_YESNO_MIXEDCASE_TRUE'),
+            array('VALID_YESNO_MIXEDCASE_FALSE'),
+        );
     }
 
     /**
@@ -68,17 +68,17 @@ class ValidatorBooleanTest extends PHPUnit_Framework_TestCase
      */
     public function invalidBooleanValuesDataProvider()
     {
-        return [
-            ['INVALID_SOMETHING'],
-            ['INVALID_EMPTY'],
-            ['INVALID_EMPTY_STRING'],
-            ['INVALID_NULL'],
-            ['INVALID_NUMBER_POSITIVE'],
-            ['INVALID_NUMBER_NEGATIVE'],
-            ['INVALID_MINUS'],
-            ['INVALID_TILDA'],
-            ['INVALID_EXCLAMATION'],
-        ];
+        return array(
+            array('INVALID_SOMETHING'),
+            array('INVALID_EMPTY'),
+            array('INVALID_EMPTY_STRING'),
+            array('INVALID_NULL'),
+            array('INVALID_NUMBER_POSITIVE'),
+            array('INVALID_NUMBER_NEGATIVE'),
+            array('INVALID_MINUS'),
+            array('INVALID_TILDA'),
+            array('INVALID_EXCLAMATION'),
+        );
     }
 
     /**


### PR DESCRIPTION
it builds: https://travis-ci.org/scratchers/phpdotenv/builds/198163739